### PR TITLE
Change author name 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ gem 'seed_dump'
 # Use kaminari as the pagination engine
 gem 'kaminari'
 
+# mysql gem driver for prod and test
+gem 'mysql'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
     mini_portile (0.6.2)
     minitest (5.6.0)
     multi_json (1.11.0)
+    mysql (2.9.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     orm_adapter (0.5.0)
@@ -185,6 +186,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   less-rails
+  mysql
   rails (= 4.2.1)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,9 +10,11 @@ default: &default
   timeout: 5000
 
 development:
-  <<: *default
-  database: db/development.sqlite3
-
+  adapter: mysql
+  database: test
+  username: root
+  password: password
+  host: localhost
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.

--- a/db/migrate/20150509182058_change_author_name_to_text.rb
+++ b/db/migrate/20150509182058_change_author_name_to_text.rb
@@ -1,0 +1,5 @@
+class ChangeAuthorNameToText < ActiveRecord::Migration
+  def change
+    change_column :authors, :name, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,94 +11,104 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150502051020) do
+ActiveRecord::Schema.define(version: 20150509182058) do
 
   create_table "authors", force: :cascade do |t|
-    t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.text     "name",       limit: 65535
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
   end
 
   create_table "categories", force: :cascade do |t|
-    t.string   "content"
-    t.integer  "quote_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "content",    limit: 255
+    t.integer  "quote_id",   limit: 4
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
-  add_index "categories", ["quote_id"], name: "index_categories_on_quote_id"
+  add_index "categories", ["quote_id"], name: "index_categories_on_quote_id", using: :btree
 
   create_table "categorizations", force: :cascade do |t|
-    t.integer  "quote_id"
-    t.integer  "category_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "quote_id",    limit: 4
+    t.integer  "category_id", limit: 4
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
   end
 
-  add_index "categorizations", ["category_id"], name: "index_categorizations_on_category_id"
-  add_index "categorizations", ["quote_id"], name: "index_categorizations_on_quote_id"
+  add_index "categorizations", ["category_id"], name: "index_categorizations_on_category_id", using: :btree
+  add_index "categorizations", ["quote_id"], name: "index_categorizations_on_quote_id", using: :btree
 
   create_table "comments", force: :cascade do |t|
-    t.text     "content"
-    t.integer  "quote_id"
-    t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.text     "content",    limit: 65535
+    t.integer  "quote_id",   limit: 4
+    t.integer  "user_id",    limit: 4
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
   end
 
-  add_index "comments", ["quote_id"], name: "index_comments_on_quote_id"
-  add_index "comments", ["user_id"], name: "index_comments_on_user_id"
+  add_index "comments", ["quote_id"], name: "index_comments_on_quote_id", using: :btree
+  add_index "comments", ["user_id"], name: "index_comments_on_user_id", using: :btree
 
   create_table "favorite_quotes", force: :cascade do |t|
-    t.integer  "quote_id"
-    t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "quote_id",   limit: 4
+    t.integer  "user_id",    limit: 4
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
   end
 
-  add_index "favorite_quotes", ["quote_id"], name: "index_favorite_quotes_on_quote_id"
-  add_index "favorite_quotes", ["user_id"], name: "index_favorite_quotes_on_user_id"
+  add_index "favorite_quotes", ["quote_id"], name: "index_favorite_quotes_on_quote_id", using: :btree
+  add_index "favorite_quotes", ["user_id"], name: "index_favorite_quotes_on_user_id", using: :btree
 
   create_table "quotes", force: :cascade do |t|
-    t.text     "content"
-    t.integer  "author_id"
-    t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.text     "content",    limit: 65535
+    t.integer  "author_id",  limit: 4
+    t.integer  "user_id",    limit: 4
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
   end
 
-  add_index "quotes", ["author_id"], name: "index_quotes_on_author_id"
-  add_index "quotes", ["content", "author_id"], name: "index_quotes_on_content_and_author_id", unique: true
-  add_index "quotes", ["user_id"], name: "index_quotes_on_user_id"
+  add_index "quotes", ["author_id"], name: "index_quotes_on_author_id", using: :btree
+  add_index "quotes", ["user_id"], name: "index_quotes_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
+    t.string   "email",                  limit: 255, default: "", null: false
+    t.string   "encrypted_password",     limit: 255, default: "", null: false
+    t.string   "reset_password_token",   limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          limit: 4,   default: 0,  null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
+    t.string   "current_sign_in_ip",     limit: 255
+    t.string   "last_sign_in_ip",        limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "users", ["email"], name: "index_users_on_email", unique: true
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
   create_table "votes", force: :cascade do |t|
-    t.integer  "value"
-    t.integer  "user_id"
-    t.integer  "quote_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "value",      limit: 4
+    t.integer  "user_id",    limit: 4
+    t.integer  "quote_id",   limit: 4
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
   end
 
-  add_index "votes", ["quote_id", "user_id"], name: "index_votes_on_quote_id_and_user_id", unique: true
-  add_index "votes", ["quote_id"], name: "index_votes_on_quote_id"
-  add_index "votes", ["user_id"], name: "index_votes_on_user_id"
+  add_index "votes", ["quote_id", "user_id"], name: "index_votes_on_quote_id_and_user_id", unique: true, using: :btree
+  add_index "votes", ["quote_id"], name: "index_votes_on_quote_id", using: :btree
+  add_index "votes", ["user_id"], name: "index_votes_on_user_id", using: :btree
 
+  add_foreign_key "categories", "quotes"
+  add_foreign_key "categorizations", "categories"
+  add_foreign_key "categorizations", "quotes"
+  add_foreign_key "comments", "quotes"
+  add_foreign_key "comments", "users"
+  add_foreign_key "favorite_quotes", "quotes"
+  add_foreign_key "favorite_quotes", "users"
+  add_foreign_key "quotes", "authors"
+  add_foreign_key "quotes", "users"
+  add_foreign_key "votes", "quotes"
+  add_foreign_key "votes", "users"
 end


### PR DESCRIPTION
- ActiveRecord string type corresponds to bounded string of 255 bytes in mysql
- Some fields in the column "name" were exceeding this limit. 
- Adds migration to switch the name column in the authors table from "string" to "text". 
