### PR TITLE
New relic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,7 @@ group :production do
 end
 
 gem 'mocha', group: :test
+
+# new relic performance monitoring
+gem 'newrelic_rpm'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
     multipart-post (2.0.0)
     mysql (2.9.1)
     mysql2 (0.3.18)
+    newrelic_rpm (3.12.0.288)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     oauth (0.4.7)
@@ -248,6 +249,7 @@ DEPENDENCIES
   mocha
   mysql
   mysql2
+  newrelic_rpm
   omniauth
   omniauth-twitter
   rack-mini-profiler

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,0 +1,49 @@
+#
+# This file configures the New Relic Agent.  New Relic monitors Ruby, Java,
+# .NET, PHP, Python and Node applications with deep visibility and low
+# overhead.  For more information, visit www.newrelic.com.
+#
+# Generated May 23, 2015
+# 
+# This configuration file is custom generated for Quotopia
+#
+# For full documentation of agent configuration options, please refer to
+# https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration
+
+common: &default_settings
+  # Required license key associated with your New Relic account.
+  license_key: 9fe85aa3a0f6cbc6edfe18418023c894f0393258
+
+  # Your application name. Renaming here affects where data displays in New
+  # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
+  app_name: Quotopia
+
+  # To disable the agent regardless of other settings, uncomment the following:
+  # agent_enabled: false
+
+  # Logging level for log/newrelic_agent.log
+  log_level: info
+
+
+# Environment-specific settings are in this section.
+# RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.
+# If your application has other named environments, configure them here.
+development:
+  <<: *default_settings
+  app_name: My Application (Development)
+
+  # NOTE: There is substantial overhead when running in developer mode.
+  # Do not use for production or load testing.
+  developer_mode: true
+
+test:
+  <<: *default_settings
+  # It doesn't make sense to report to New Relic from automated test runs.
+  monitor_mode: false
+
+staging:
+  <<: *default_settings
+  app_name: My Application (Staging)
+
+production:
+  <<: *default_settings


### PR DESCRIPTION
- Since this adds the new relic middleware, it could add overhead to applications.
- May want to restrict this gem to only be included in production 
